### PR TITLE
Problem: compilation warnings

### DIFF
--- a/lib/exzmq/supervisor.ex
+++ b/lib/exzmq/supervisor.ex
@@ -6,7 +6,6 @@ defmodule Exzmq.Supervisor do
   use Supervisor
 
   def start_link() do
-    IO.puts "supervisor start_link "
     :supervisor.start_link({:local, __MODULE__}, __MODULE__, [])
   end
 

--- a/test/exzmp_test.exs
+++ b/test/exzmp_test.exs
@@ -154,7 +154,7 @@ defmodule ExzmqTest do
 
     ## send a message for each client Socket and expect a result on each socket
     Enum.each(s2, fn(_s) -> :ok = Exzmq.send(s1, [msg]) end)
-    Enum.each(s2, fn(s) -> {:ok, [msg]} = Exzmq.recv(s) end)
+    Enum.each(s2, fn(s) -> {:ok, [^msg]} = Exzmq.recv(s) end)
 
     :ok = Exzmq.close(s1)
     Enum.each(s2, fn(s) -> :ok = Exzmq.close(s) end)
@@ -166,7 +166,7 @@ defmodule ExzmqTest do
 
     ## send a message for each client Socket and expect a result on each socket
     Enum.each(s2, fn(_s) -> :ok = Exzmq.send(s1, [msg]) end)
-    Enum.each(s2, fn(s) -> {:ok, [msg]} = Exzmq.recv(s) end)
+    Enum.each(s2, fn(s) -> {:ok, [^msg]} = Exzmq.recv(s) end)
 
     :ok = Exzmq.close(s1)
     Enum.each(s2, fn(s) -> :ok = Exzmq.close(s) end)
@@ -178,7 +178,7 @@ defmodule ExzmqTest do
 
     ## send a message for each client Socket and expect a result on each socket
     Enum.each(s2, fn(s) -> :ok = Exzmq.send(s, [msg]) end)
-    Enum.each(s2, fn(_s) -> {:ok, [msg]} = Exzmq.recv(s1) end)
+    Enum.each(s2, fn(_s) -> {:ok, [^msg]} = Exzmq.recv(s1) end)
 
     :ok = Exzmq.close(s1)
     Enum.each(s2, fn(s) -> :ok = Exzmq.close(s) end)
@@ -200,10 +200,10 @@ defmodule ExzmqTest do
     ## send a message for each client Socket and expect a result on each socket
     Enum.each(s2, fn(s) -> :ok = Exzmq.send(s, [msg]) end)
     Enum.each(s2, fn(_s) ->
-      {:ok, {id, [msg]}} = Exzmq.recv(s1)
+      {:ok, {id, [^msg]}} = Exzmq.recv(s1)
       :ok = Exzmq.send(s1, {id, [msg]})
       end)
-    Enum.each(s2, fn(s) -> {:ok, msg} = Exzmq.recv(s) end)
+    Enum.each(s2, fn(s) -> {:ok, _msg} = Exzmq.recv(s) end)
     :ok = Exzmq.close(s1)
     Enum.each(s2, fn(s) -> :ok = Exzmq.close(s) end)
   end
@@ -222,7 +222,7 @@ defmodule ExzmqTest do
       {:ok, [msg]} = Exzmq.recv(s1)
       :ok = Exzmq.send(s1, [msg])
       end)
-    Enum.each(s2, fn(s) -> {:ok, [msg]} = Exzmq.recv(s) end)
+    Enum.each(s2, fn(s) -> {:ok, [^msg]} = Exzmq.recv(s) end)
     :ok = Exzmq.close(s1)
     Enum.each(s2, fn(s) -> :ok = Exzmq.close(s) end)
   end
@@ -238,7 +238,7 @@ defmodule ExzmqTest do
     ## receive a message for each client and expect a result on each socket
     {:error, :fsm} = Exzmq.recv(s1)
     :ok = Exzmq.send(s1, [msg])
-    Enum.each(s2, fn(s) -> {:ok, [msg]} = Exzmq.recv(s) end)
+    Enum.each(s2, fn(s) -> {:ok, [^msg]} = Exzmq.recv(s) end)
     :ok = Exzmq.close(s1)
     Enum.each(s2, fn(s) -> :ok = Exzmq.close(s) end)
   end


### PR DESCRIPTION
Solution: remove @doc comments for private functions, use Socket alias,
match against msg variable in tests, also remove unnecessary IO.puts.