### PR TITLE
Problem: there are compiler warnings and Credo issues

### DIFF
--- a/lib/exzmq/acceptor.ex
+++ b/lib/exzmq/acceptor.ex
@@ -13,7 +13,7 @@ defmodule Exzmq.Acceptor do
 
   def init(state) do
     IO.puts "Acceptor started"
-    GenServer.cast(self, :accept)
+    GenServer.cast(self(), :accept)
     {:ok, state}
   end
 
@@ -27,7 +27,7 @@ defmodule Exzmq.Acceptor do
       error ->
         IO.puts "Not accepted: #{inspect error}"
     end
-    GenServer.cast(self, :accept)
+    GenServer.cast(self(), :accept)
     {:noreply, state}
   end
 

--- a/lib/exzmq/address.ex
+++ b/lib/exzmq/address.ex
@@ -9,15 +9,13 @@ defmodule Exzmq.Address do
   # port: the port number
   defstruct transport: :tcp, ip: nil, port: nil
 
-  def parse(%Exzmq.Address{} = address) do
-    address
-  end
+  def parse(%Exzmq.Address{} = address), do: address
   def parse(address) do
     unless address |> String.starts_with?("tcp://") do
       raise "Unsupported transport: #{address}"
     end
     [ip, port] = address
-    |> String.slice(6,999)
+    |> String.slice(6, 999)
     |> String.split(":")
     {:ok, ip} = ip |> String.to_char_list |> :inet.parse_address
     %Exzmq.Address{ip: ip, port: port |> String.to_integer}

--- a/lib/exzmq/command.ex
+++ b/lib/exzmq/command.ex
@@ -12,10 +12,10 @@ defmodule Exzmq.Command do
   encoded_metadata = metadata
   |> Map.put(:"Server-Type", type)
   |> encode_metadata
-  metadata_size = encoded_metadata |> byte_size
+  #metadata_size = encoded_metadata |> byte_size
   ready = [<<0xd5, "READY">>, encoded_metadata] |> IO.iodata_to_binary
   ready_size = ready |> byte_size
-  if(ready_size <= 255) do
+  if ready_size <= 255  do
     [<<0x04, ready_size::size(8)>>, ready] |> IO.iodata_to_binary
   else
     [<<0x06, ready_size::size(64)>>, ready] |> IO.iodata_to_binary
@@ -29,7 +29,7 @@ defmodule Exzmq.Command do
       ks = k |> Atom.to_string
       kl = ks |> String.length
       vl = v |> String.length
-      acc = acc ++ [kl,ks,<<vl::size(32)>>, v]
+      acc = acc ++ [kl, ks, <<vl::size(32)>>, v]
       {e, acc}
       end)
     |> elem(1)

--- a/lib/exzmq/frame.ex
+++ b/lib/exzmq/frame.ex
@@ -4,16 +4,16 @@
 
 defmodule Exzmq.Frame do
 
-  def decode(<<0x00,len::size(8),payload::binary>>) do
+  def decode(<<0x00, len::size(8), payload::binary>>) do
     payload
   end
 
   def encode(msg) when is_binary(msg) do
     msg_len = msg |> byte_size
     if msg_len > 255 do
-      [<<0x02,msg_len::size(64)>>,msg] |> IO.iodata_to_binary
+      [<<0x02, msg_len::size(64)>>, msg] |> IO.iodata_to_binary
     else
-      [<<0x00,msg_len::size(8)>>,msg] |> IO.iodata_to_binary
+      [<<0x00, msg_len::size(8)>>, msg] |> IO.iodata_to_binary
     end
   end
 


### PR DESCRIPTION
Solution: fix credo and compiler warnings

There were quite a few compiler warnings and Credo issues using Elixir
1.5.x and a newer version of Credo. This patch addresses all of them
execpt for one in Exzmq.Frame.decode which shouldn't matter for the
match but may make sense to keep in for clarity.