### PR TITLE
Problem: CI tests are using an outdated version of Elixir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 sudo: false
 elixir:
-  - 1.1.0
+  - 1.5.2
 otp_release:
-  - 18.1
+  - 20.1

--- a/lib/exzmq/address.ex
+++ b/lib/exzmq/address.ex
@@ -17,7 +17,7 @@ defmodule Exzmq.Address do
     [ip, port] = address
     |> String.slice(6, 999)
     |> String.split(":")
-    {:ok, ip} = ip |> String.to_char_list |> :inet.parse_address
+    {:ok, ip} = ip |> String.to_charlist |> :inet.parse_address
     %Exzmq.Address{ip: ip, port: port |> String.to_integer}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Exzmq.Mixfile do
       version: @version,
       elixir: ">= 1.1.0",
       name: "Exzmq",
-      package: package,
+      package: package(),
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: [


### PR DESCRIPTION
Solution: update the test dependencies

Update .travis.yml to use newer version of Elixir and OTP. This also
fixes a different compiler warning and deprecation notice as a result of
the upgrade